### PR TITLE
Add missing spacing between 'animated' and the leave-transition 

### DIFF
--- a/src/common/generic-transition/index.js
+++ b/src/common/generic-transition/index.js
@@ -39,7 +39,7 @@ export default class GenericTransition {
         props: {
           name: self.name,
           enterActiveClass: self.enterTransition !== '' ? 'animated ' + self.enterTransition : '',
-          leaveActiveClass: self.leaveTransition !== '' ? 'animated' + self.leaveTransition : ''
+          leaveActiveClass: self.leaveTransition !== '' ? 'animated ' + self.leaveTransition : ''
         },
         on: {
           beforeEnter (el) {


### PR DESCRIPTION
This fixes the broken leave transition set when using the GenericTransition class for custom animations.